### PR TITLE
Remove examples from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'Operating System :: POSIX :: Linux',
     ],
 
-    packages=find_packages(exclude=['tests*']),
+    packages=find_packages(exclude=['tests*', 'examples']),
 
     install_requires=[
         'base58==0.2.2',


### PR DESCRIPTION
Installing `cryptoconditions` installs also an extra package called `examples`. This PR is to remove `examples` from the installation.