### PR TITLE
inverted fulfillment

### DIFF
--- a/cryptoconditions/__init__.py
+++ b/cryptoconditions/__init__.py
@@ -1,6 +1,7 @@
 from cryptoconditions.type_registry import TypeRegistry
 from cryptoconditions.types.sha256 import PreimageSha256Fulfillment
 from cryptoconditions.types.threshold_sha256 import ThresholdSha256Fulfillment
+from cryptoconditions.types.inverted_threshold_sha256 import InvertedThresholdSha256Fulfillment
 from cryptoconditions.types.ed25519 import Ed25519Fulfillment
 from cryptoconditions.types.timeout import TimeoutFulfillment
 from cryptoconditions.fulfillment import Fulfillment
@@ -9,5 +10,6 @@ from cryptoconditions.condition import Condition
 
 TypeRegistry.register_type(PreimageSha256Fulfillment)
 TypeRegistry.register_type(ThresholdSha256Fulfillment)
+TypeRegistry.register_type(InvertedThresholdSha256Fulfillment)
 TypeRegistry.register_type(Ed25519Fulfillment)
 TypeRegistry.register_type(TimeoutFulfillment)

--- a/cryptoconditions/types/ed25519.py
+++ b/cryptoconditions/types/ed25519.py
@@ -122,7 +122,7 @@ class Ed25519Fulfillment(Fulfillment):
         return json.dumps(
             {
                 'type': 'fulfillment',
-                'type_id': Ed25519Fulfillment.TYPE_ID,
+                'type_id': self.TYPE_ID,
                 'bitmask': self.bitmask,
                 'public_key': self.public_key.to_ascii(encoding='base58').decode(),
                 'signature': base58.b58encode(self.signature) if self.signature else None

--- a/cryptoconditions/types/inverted_threshold_sha256.py
+++ b/cryptoconditions/types/inverted_threshold_sha256.py
@@ -1,0 +1,23 @@
+from cryptoconditions import ThresholdSha256Fulfillment
+
+CONDITION = 'condition'
+FULFILLMENT = 'fulfillment'
+
+
+class InvertedThresholdSha256Fulfillment(ThresholdSha256Fulfillment):
+    TYPE_ID = 98
+    FEATURE_BITMASK = 0x09
+
+    def validate(self, message=None, **kwargs):
+        """
+        Check whether this fulfillment meets all validation criteria.
+
+        This will validate the subfulfillments and verify that there are enough
+        subfulfillments to meet the threshold.
+
+        Args:
+            message (str): message to validate against
+        Returns:
+            boolean: Whether this fulfillment is valid.
+        """
+        return not super().validate(message, **kwargs)

--- a/cryptoconditions/types/sha256.py
+++ b/cryptoconditions/types/sha256.py
@@ -102,7 +102,7 @@ class PreimageSha256Fulfillment(BaseSha256Fulfillment):
         return json.dumps(
             {
                 'type': 'fulfillment',
-                'type_id': PreimageSha256Fulfillment.TYPE_ID,
+                'type_id': self.TYPE_ID,
                 'bitmask': self.bitmask,
                 'preimage': self.preimage.decode()
             }

--- a/cryptoconditions/types/timeout.py
+++ b/cryptoconditions/types/timeout.py
@@ -41,7 +41,7 @@ class TimeoutFulfillment(PreimageSha256Fulfillment):
         return json.dumps(
             {
                 'type': 'fulfillment',
-                'type_id': TimeoutFulfillment.TYPE_ID,
+                'type_id': self.TYPE_ID,
                 'bitmask': self.bitmask,
                 'expire_time': self.expire_time.decode()
             }

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ docs_require = [
 
 setup(
     name='cryptoconditions',
-    version='0.3.0',
+    version='0.3.1',
     description='Multi-algorithm, multi-level, multi-signature format for '
                 'expressing conditions and fulfillments according to the Interledger Protocol (ILP).',
     long_description=__doc__,


### PR DESCRIPTION
Instead of inverted weights, which is incompatible with interledger, provide an inverted threshold.

This component is incompatible with interledger,  but can be used in-house without interfering with the normal thresholdcondition.

The reason for incompatibility lies in the following:
- one can not prove that a fact happened but evaluated to False
- one can only prove that a condition happened and evaluated to True