### PR TITLE
Closes #36

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ setup(
     packages=find_packages(exclude=['tests*', 'examples']),
 
     install_requires=[
-        'base58==0.2.2',
-        'PyNaCl==1.0.1',
+        'base58~=0.2.2',
+        'PyNaCl~=1.0.1',
     ],
     setup_requires=['pytest-runner'],
     tests_require=tests_require,


### PR DESCRIPTION
this should help prevent problems such as https://github.com/bigchaindb/bigchaindb/pull/785#issue-186972441 to occur

In line with guidelines in https://packaging.python.org/requirements/#install-requires:

> It is not considered best practice to use `install_requires` to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.