### PR TITLE
Update to last stable version of PyNaCl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
 
     install_requires=[
         'base58~=0.2.2',
-        'PyNaCl~=1.0.1',
+        'PyNaCl~=1.1.0',
     ],
     setup_requires=['pytest-runner'],
     tests_require=tests_require,


### PR DESCRIPTION
I'm using `bigchaindb-driver` (hence `bigchaindb`, hence `cryptoconditions`) in another project. PyNaCl 1.1 has some nice improvements for `nacl.secret` that I'd like to use.

In the CC code we just use `nacl.signing`. Tests are all green, so everything should work as expected.