### PR TITLE
Add .coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = .
+omit = *test*, docs/*, setup.py, cryptoconditions/version.py


### PR DESCRIPTION
This file is used to configure [coverage.py](https://coverage.readthedocs.io/en/coverage-4.4.1/). This is useful to check the test coverage, on one's own local machine.

Information about the configuration file can be found at https://coverage.readthedocs.io/en/coverage-4.4.1/config.html