### PR TITLE
added missing import for base58

### DIFF
--- a/cryptoconditions/condition.py
+++ b/cryptoconditions/condition.py
@@ -1,4 +1,5 @@
 import base64
+import base58
 import re
 from functools import total_ordering
 from itertools import compress


### PR DESCRIPTION
There was a missing import of `base58` in `conditions.py` that is needed by the `to_dict()` method. 