### PR TITLE
Problems: base58 library can lead to conflicts, and cryptography package out-of-date

### DIFF
--- a/cryptoconditions/crypto.py
+++ b/cryptoconditions/crypto.py
@@ -12,7 +12,7 @@ class Base58Encoder(object):
 
     @staticmethod
     def encode(data):
-        return base58.b58encode(data).encode()
+        return base58.b58encode(data)
 
     @staticmethod
     def decode(data):

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'base58~=1.0.0',
         'PyNaCl~=1.1.0',
         'pyasn1~=0.4',
-        'cryptography~=1.9',
+        'cryptography~=2.3.1',
     ],
     setup_requires=['pytest-runner'],
     tests_require=tests_require,

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     packages=find_packages(exclude=['tests*', 'examples']),
 
     install_requires=[
-        'base58~=0.2.2',
+        'base58~=1.0.0',
         'PyNaCl~=1.1.0',
         'pyasn1~=0.4',
         'cryptography~=1.9',


### PR DESCRIPTION
Solution: upgrade to the newest versions of `base58` and `cryptography`

fixes #107
fixes #105