### PR TITLE
Problem: `make release` doesn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
-release: clean ## package and upload a release
+release: dist ## package and upload a release
 	twine upload dist/*
 
 dist: clean ## builds source and wheel package


### PR DESCRIPTION
Solution: Edit Makefile so `make release` depends on `make dist` being done first

Note: `make dist` in turn depends on `make clean` being done first