### PR TITLE
Problem: cryptoconditions dependency updated because of vulnerability

### DIFF
--- a/cryptoconditions/types/rsa.py
+++ b/cryptoconditions/types/rsa.py
@@ -142,14 +142,14 @@ class RsaSha256(BaseSha256):
                 (m_int.bit_length() + 7) // 8, 'big')
             self._set_public_modulus(m_bytes)
 
-        signer = private_key_obj.signer(
+        signer = private_key_obj.sign(
+            message,
             padding.PSS(
                 mgf=padding.MGF1(hashes.SHA256()),
                 salt_length=SALT_LENGTH,
             ),
             hashes.SHA256(),
         )
-        signer.update(message)
         self.signature = signer.finalize()
 
     def calculate_cost(self):
@@ -198,7 +198,8 @@ class RsaSha256(BaseSha256):
             int.from_bytes(self.modulus, byteorder='big'),
         )
         public_key = public_numbers.public_key(default_backend())
-        verifier = public_key.verifier(
+        verifier = public_key.verify(
+            message,
             self.signature,
             padding.PSS(
                 mgf=padding.MGF1(hashes.SHA256()),
@@ -206,7 +207,6 @@ class RsaSha256(BaseSha256):
             ),
             hashes.SHA256()
         )
-        verifier.update(message)
         try:
             verifier.verify()
         except InvalidSignature as exc:

--- a/cryptoconditions/types/rsa.py
+++ b/cryptoconditions/types/rsa.py
@@ -142,7 +142,7 @@ class RsaSha256(BaseSha256):
                 (m_int.bit_length() + 7) // 8, 'big')
             self._set_public_modulus(m_bytes)
 
-        signer = private_key_obj.sign(
+        self.signature = private_key_obj.sign(
             message,
             padding.PSS(
                 mgf=padding.MGF1(hashes.SHA256()),
@@ -150,7 +150,6 @@ class RsaSha256(BaseSha256):
             ),
             hashes.SHA256(),
         )
-        self.signature = signer.finalize()
 
     def calculate_cost(self):
         """Calculate the cost of fulfilling self condition.
@@ -198,17 +197,16 @@ class RsaSha256(BaseSha256):
             int.from_bytes(self.modulus, byteorder='big'),
         )
         public_key = public_numbers.public_key(default_backend())
-        verifier = public_key.verify(
-            message,
-            self.signature,
-            padding.PSS(
-                mgf=padding.MGF1(hashes.SHA256()),
-                salt_length=SALT_LENGTH,
-            ),
-            hashes.SHA256()
-        )
         try:
-            verifier.verify()
+            public_key.verify(
+                        self.signature,
+                        message,
+                        padding.PSS(
+                            mgf=padding.MGF1(hashes.SHA256()),
+                            salt_length=SALT_LENGTH,
+                        ),
+                        hashes.SHA256()
+                    )
         except InvalidSignature as exc:
             raise ValidationError('Invalid RSA signature') from exc
 


### PR DESCRIPTION
cyrptoconditions dependency updated because of vulnerability CVE-2018-10903

- signer and verifier are deprecated -> use sign() and verify()

Resolves #105
Resolves #107