### PR TITLE
Revert change in PyNaCl version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
 
     install_requires=[
         'base58~=1.0.0',
-        'PyNaCl~=1.2.1',
+        'PyNaCl~=1.1.0',
         'pyasn1~=0.4',
         'cryptography~=2.3.1',
     ],


### PR DESCRIPTION
This commit reverts commit 433a9ba3f297e442c2d30d7204a08835a096005d
which changed `PyNaCl~=1.1.0` to `PyNaCl~=1.2.1` in `setup.py`
because that change broke software using this package (cryptoconditions), such as bigchaindb-driver.